### PR TITLE
Solved issue #661 ,Id value issue for radio groups

### DIFF
--- a/app/client/src/mockResponses/WidgetConfigResponse.tsx
+++ b/app/client/src/mockResponses/WidgetConfigResponse.tsx
@@ -155,8 +155,8 @@ const WidgetConfigResponse: WidgetConfigReducerState = {
       columns: 3,
       label: "",
       options: [
-        { id: "1", label: "Male", value: "M" },
-        { id: "2", label: "Female", value: "F" },
+        { label: "Male", value: "M" },
+        { label: "Female", value: "F" },
       ],
       defaultOptionValue: "M",
       widgetName: "RadioGroup",


### PR DESCRIPTION
There was issue related to id value while creating new radio group options other than the default ones . And as said I, the id field is not needed at all, but some old config still has the id field.
So since ID field is not required , I have removed it . Which solves the issue I think .