### PR TITLE
PageName didn't allow special chacater #955

### DIFF
--- a/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
+++ b/app/client/src/pages/Editor/Explorer/Pages/PageEntity.tsx
@@ -14,7 +14,6 @@ import { DataTreeAction } from "entities/DataTree/dataTreeFactory";
 import { homePageIcon, pageIcon } from "../ExplorerIcons";
 import { getActionGroups } from "../Actions/helpers";
 import ExplorerWidgetGroup from "../Widgets/WidgetGroup";
-import { resolveAsSpaceChar } from "utils/helpers";
 
 type ExplorerPageEntityProps = {
   page: Page;
@@ -66,7 +65,6 @@ export const ExplorerPageEntity = (props: ExplorerPageEntityProps) => {
       isDefaultExpanded={isCurrentPage || !!props.searchKeyword}
       updateEntityName={updatePage}
       contextMenu={contextMenu}
-      onNameEdit={resolveAsSpaceChar}
     >
       <ExplorerWidgetGroup
         step={props.step + 1}


### PR DESCRIPTION
Page names were not accepting special characters , there is a function 'resolveAsSpaceChar'  in helpers , that converted any special character to a space , which was being used in the page name editor , ''onNameEdit" , I have removed this from the part and thus now special charcaters are allowed. Solving issue #955